### PR TITLE
Precached models and sv_pure bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ The skin chager currently is able to change:
 #### Model changer
 There are currently 2 model changer methods. `find_mdl` and precached models. `sv_pure` bypass is integrated in the cheat.
 
+The model changer is currently able to change:
+- [X] Weapons
+    - [X] Normal weapons
+    - [X] Knifes
+- [X] Players
+    - [X] Localplayer
+    - [X] Allies
+    - [X] Enemies
+- [ ] Arms
+
 :warning: All the models need to be downloaded manually.
 
 - When using `find_mdl`, it will hook to the function, and when the game tries to load a model, we will replace it with our own. `find_mdl` model paths are hardcoded in [`models.hpp`](https://github.com/r4v10l1/NullHooks/blob/main/src/core/features/visuals/models.hpp). In that file explains where to put the models and all that. If an item is `NULL` it will be ignored.
@@ -133,6 +143,10 @@ A good example of a json file for replacing the knives usin precached models wou
     
 ```json
 {
+    "LOCAL_PLAYER": "models/player/custom_player/kuristaja/hitler/hitler.mdl",
+	"PLAYER_ALLY": "models/player/custom_player/kolka/master_chief/master_chief.mdl",
+	"PLAYER_ENEMY": "models/player/custom_player/nier_2b/nier_2b.mdl",
+
 	"WEAPON_KNIFE": {
 		"item_definition_index": "WEAPON_KNIFE_KARAMBIT"
 	},
@@ -160,6 +174,8 @@ A good example of a json file for replacing the knives usin precached models wou
 	}
 }
 ```
+
+The first 3 lines are for changing special models. In this case ally players, enemy players and localplayer. See special models here: [Link](https://github.com/r4v10l1/NullHooks/blob/824b745d9fc17f139d6e6a223fa5533f52664e8c/src/source-sdk/classes/entities.hpp#L307-L312).
 
 Changes the default ct knife index to the karambit one, automatically changing the models and applaying the skins of the karambit. Since there is a custom viewmodel and worlmodel, the model will change but the rarity, skin name, kill icon, etc. will be the same.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,55 @@ The skin chager currently is able to change:
 - [ ] Globes
 
 #### Model changer
-The model changer uses findmdl to replace the models, and you need to download them manually. Because of this, the models are not enabled by default (at least for now). You need change your custom path in [`models.hpp`](https://github.com/r4v10l1/NullHooks/blob/main/src/core/features/visuals/models.hpp) (`NULL` means it's disabled).
+There are currently 2 model changer methods. `find_mdl` and precached models. `sv_pure` bypass is integrated in the cheat.
+
+:warning: All the models need to be downloaded manually.
+
+- When using `find_mdl`, it will hook to the function, and when the game tries to load a model, we will replace it with our own. `find_mdl` model paths are hardcoded in [`models.hpp`](https://github.com/r4v10l1/NullHooks/blob/main/src/core/features/visuals/models.hpp). In that file explains where to put the models and all that. If an item is `NULL` it will be ignored.
+- Precached models are a way better alternative, because with my json config system you can edit and load the file any time you want during a match. For adding models to a weapon, simply add to the skin json the following options:
+    - `"viewmodel"`: The viewmodel path from the csgo directory. The viewmodel files usually start with `v_`.  
+    *Example: `"models/weapons/eminem/bananabit/v_bananabit.mdl"`*
+    - `"worldmodel"`: The worldmodel path from the csgo directory. The worldmodel files usually start with `w_`.  
+    *Example: `"models/weapons/eminem/bananabit/w_bananabit.mdl"`*
+
+A good example of a json file for replacing the knives usin precached models would be like this:
+<details>
+    <summary>Example skins.json file and explanation</summary>
+    
+```json
+{
+	"WEAPON_KNIFE": {
+		"item_definition_index": "WEAPON_KNIFE_KARAMBIT"
+	},
+	"WEAPON_KNIFE_T": {
+		"item_definition_index": "WEAPON_KNIFE_WIDOWMAKER"
+	},
+	"WEAPON_KNIFE_WIDOWMAKER": {
+		"paint_kit": 416,
+		"seed": 420,
+		"quality": "SKIN_QUALITY_VINTAGE"
+	},
+	"WEAPON_BAYONET": {
+		"paint_kit": 44,
+		"seed": 555,
+		"quality": "SKIN_QUALITY_CUSTOMIZED",
+		"viewmodel": "models/weapons/caleon1/screwdriver/v_knife_screwdriver.mdl",
+		"worldmodel": "models/weapons/caleon1/screwdriver/w_knife_screwdriver.mdl"
+	},
+	"WEAPON_KNIFE_KARAMBIT": {
+		"paint_kit": 416,
+		"seed": 69,
+		"quality": "SKIN_QUALITY_GENUINE",
+		"viewmodel": "models/weapons/eminem/bananabit/v_bananabit.mdl",
+		"worldmodel": "models/weapons/eminem/bananabit/w_bananabit.mdl"
+	}
+}
+```
+
+Changes the default ct knife index to the karambit one, automatically changing the models and applaying the skins of the karambit. Since there is a custom viewmodel and worlmodel, the model will change but the rarity, skin name, kill icon, etc. will be the same.
+
+You can add viewmodels to weapons that you are not currently using like the bayonet in this case. Right now we are replacing the terrorist knife with a *Vintage Talon Knife Zaphire*, but if we wanted to change that, we could just edit the file, replace the `"item_definition_index"` of the terrorist knife to the `WEAPON_BAYONET`, load the skins config from the config tab and press the full update button.
+</details>
 
 #### Misc
 - C4 timer and bar
@@ -258,6 +306,10 @@ This method is not recommended as the cheat can be a bit outdated and you might 
 - [X] Add can't shoot to player ESP
 - [X] Add textbox to framework for creating new config files from menu
 - [X] Add antiaim
+- [X] Add killicons to knife skinchanger
+- [X] Replace `player_info` esp with multicombobox
+- [X] Replace `findmdl` model changer with precached models ([link](https://www.unknowncheats.me/forum/counterstrike-global-offensive/214919-precache-models.html))
+- [X] Add "defusing" to bomb timer
 #
 </details>
 
@@ -282,18 +334,14 @@ This method is not recommended as the cheat can be a bit outdated and you might 
     - [X] Add bullet tracers
         - [ ] Fix `bullet_impact` event not working in online matches (without using event listener)
     - [ ] Add [decoy timer](https://www.unknowncheats.me/forum/counterstrike-global-offensive/498498-decoys-spawn-time.html)
-- [ ] Add killicons to knife skinchanger
 - [ ] Add auto revolver hold
-- [ ] Replace `player_info` esp with multicombobox
 - [ ] Add worldcolor
-- [ ] Replace `findmdl` model changer with precached models ([link](https://www.unknowncheats.me/forum/counterstrike-global-offensive/214919-precache-models.html))
 - [ ] Port to linux
 
 #### Bugs/Fixes
 - [ ] Skinchanger fixes
     - [X] Fix talon knife inspect animation
     - [ ] Get localplayer steam id to fix weapon stattrack
-- [ ] Add "defusing" to bomb timer (When doing player esp? Check first, set bool, then check combobox and render)
 - [ ] Entity glow won't turn off on weapons (will turn off if another glow is on)
 
 ## Screenshots

--- a/src/NullHooks.vcxproj
+++ b/src/NullHooks.vcxproj
@@ -277,6 +277,7 @@
     <ClInclude Include="dependencies\interfaces\i_base_client_dll.hpp" />
     <ClInclude Include="dependencies\interfaces\i_client_entity_list.hpp" />
     <ClInclude Include="dependencies\interfaces\i_client_state.hpp" />
+    <ClInclude Include="dependencies\interfaces\i_client_string_table_container.hpp" />
     <ClInclude Include="dependencies\interfaces\i_console.hpp" />
     <ClInclude Include="dependencies\interfaces\i_game_event_manager.hpp" />
     <ClInclude Include="dependencies\interfaces\i_input.hpp" />

--- a/src/NullHooks.vcxproj
+++ b/src/NullHooks.vcxproj
@@ -174,6 +174,7 @@
     </ClCompile>
     <ClCompile Include="core\hooks\functions\render_smoke_overlay.cpp" />
     <ClCompile Include="core\hooks\functions\supports_resolve_depth.cpp" />
+    <ClCompile Include="core\hooks\functions\sv_pure.cpp" />
     <ClCompile Include="core\hooks\functions\viewmodel_sequence.cpp" />
     <ClCompile Include="core\hooks\functions\WndProc_hook.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
@@ -279,6 +280,7 @@
     <ClInclude Include="dependencies\interfaces\i_client_state.hpp" />
     <ClInclude Include="dependencies\interfaces\i_client_string_table_container.hpp" />
     <ClInclude Include="dependencies\interfaces\i_console.hpp" />
+    <ClInclude Include="dependencies\interfaces\i_filesystem.hpp" />
     <ClInclude Include="dependencies\interfaces\i_game_event_manager.hpp" />
     <ClInclude Include="dependencies\interfaces\i_input.hpp" />
     <ClInclude Include="dependencies\interfaces\i_input_system.hpp" />

--- a/src/core/features/animations/local.cpp
+++ b/src/core/features/animations/local.cpp
@@ -6,7 +6,7 @@
 void animations::local::run_local_animations() {
 	if (!csgo::local_player || !csgo::local_player->is_alive()) return;
 	if (!interfaces::engine->is_in_game() || !interfaces::engine->is_connected()) return;
-	if (!interfaces::input->camera_in_third_person || globals::forcing_update) return;		// For now we only care about local animations when on thirdperson
+	if (!interfaces::input->camera_in_third_person) return;		// For now we only care about local animations when on thirdperson
 
 	// Save the angles
 	auto angles = csgo::local_player->eye_angles();
@@ -14,5 +14,11 @@ void animations::local::run_local_animations() {
 
 	// Set them and update to apply
 	interfaces::prediction->set_local_view_angles(angles);
-	//csgo::local_player->update_client_side_animations();
+
+	/*
+	 * @todo: Fix crash when running full_update()
+
+	if (globals::forcing_update)
+		csgo::local_player->update_client_side_animations();
+	*/
 }

--- a/src/core/features/animations/local.cpp
+++ b/src/core/features/animations/local.cpp
@@ -14,5 +14,5 @@ void animations::local::run_local_animations() {
 
 	// Set them and update to apply
 	interfaces::prediction->set_local_view_angles(angles);
-	csgo::local_player->update_client_side_animations();
+	//csgo::local_player->update_client_side_animations();
 }

--- a/src/core/features/animations/local.cpp
+++ b/src/core/features/animations/local.cpp
@@ -2,10 +2,11 @@
 #include "core/features/features.hpp"
 #include "core/menu/variables.hpp"
 
+// Used in frame_stage_notify - FRAME_RENDER_START
 void animations::local::run_local_animations() {
 	if (!csgo::local_player || !csgo::local_player->is_alive()) return;
 	if (!interfaces::engine->is_in_game() || !interfaces::engine->is_connected()) return;
-	if (!interfaces::input->camera_in_third_person) return;		// For now we only care about local animations when on thirdperson
+	if (!interfaces::input->camera_in_third_person || globals::forcing_update) return;		// For now we only care about local animations when on thirdperson
 
 	// Save the angles
 	auto angles = csgo::local_player->eye_angles();

--- a/src/core/features/features.hpp
+++ b/src/core/features/features.hpp
@@ -54,7 +54,8 @@ namespace visuals {
 	void bullet_tracer(i_game_event *event);
 	void nade_predict() noexcept;
 	void nosmoke(client_frame_stage_t frame_stage);
-	
+	void apply_models();
+
 	namespace custom_models {
 		void replace_model(char* path);
 	}

--- a/src/core/features/misc/commands.cpp
+++ b/src/core/features/misc/commands.cpp
@@ -7,5 +7,5 @@ void button_functions::exec_autoexec() {
 }
 
 void button_functions::full_update() {
-	globals::forcing_update = true;
+	globals::forcing_update = true;		// Will be used in frame_stage_notify to run full_update() on a safer way
 }

--- a/src/core/features/misc/commands.cpp
+++ b/src/core/features/misc/commands.cpp
@@ -7,5 +7,5 @@ void button_functions::exec_autoexec() {
 }
 
 void button_functions::full_update() {
-	interfaces::clientstate->full_update();
+	globals::forcing_update = true;
 }

--- a/src/core/features/misc/thirdperson.cpp
+++ b/src/core/features/misc/thirdperson.cpp
@@ -30,14 +30,15 @@ void misc::thirdperson() {
         return;
     }
 
+    // From here should be only localplayer
+    if (!csgo::local_player || !csgo::local_player->is_alive()) return;
+
     // If we are alive and we are trying to throw a grenade, reset thirdperson
-    if (csgo::local_player && csgo::local_player->is_alive()) {
-        weapon_t* active_weapon = csgo::local_player->active_weapon();
-        if (!active_weapon) return;
-        if (active_weapon->is_grenade() && (input::gobal_input.IsHeld(VK_LBUTTON) || input::gobal_input.IsHeld(VK_RBUTTON))) {
-            reset_thirdperson();
-            return;
-        }
+    weapon_t* active_weapon = csgo::local_player->active_weapon();
+    if (!active_weapon) return;
+    if (active_weapon->is_grenade() && (input::gobal_input.IsHeld(VK_LBUTTON) || input::gobal_input.IsHeld(VK_RBUTTON))) {
+        reset_thirdperson();
+        return;
     }
 
     float distance = variables::misc::thirdperson_dist + 5.f;
@@ -47,13 +48,13 @@ void misc::thirdperson() {
     view_angles.z = 0.f;
 
     vec3_t forward(math::angle_vector(view_angles));
-    vec3_t eyes = player->get_eye_pos();
+    vec3_t eyes = csgo::local_player->get_eye_pos();
 
     ray_t ray;
     ray.initialize(eyes, (eyes - forward * distance));
         
     trace_filter filter;
-    filter.skip = player;
+    filter.skip = csgo::local_player;
 
     trace_t trace;
     interfaces::trace_ray->trace_ray(ray, MASK_SOLID, &filter, &trace);     // Detect hit behind (make distance smaller)
@@ -69,7 +70,7 @@ void misc::thirdperson() {
 
     using  fn = void(__thiscall*)(entity_t*);
     static fn update_visibility = (fn)utilities::pattern_scan("client.dll", sig_update_visibility);
-    update_visibility(player);      // Update visibility this way to allow thirdperson while spectating
+    update_visibility(csgo::local_player);      // Update visibility this way to allow thirdperson while spectating
 }
 
 void misc::reset_thirdperson() {
@@ -79,6 +80,7 @@ void misc::reset_thirdperson() {
         else
             csgo::local_player->observer_mode() = OBS_MODE_IN_EYE;
     }
+
     interfaces::input->camera_in_third_person = false;
     interfaces::input->camera_offset.z = 0.f;
 }

--- a/src/core/features/misc/thirdperson.cpp
+++ b/src/core/features/misc/thirdperson.cpp
@@ -27,7 +27,8 @@ void misc::thirdperson() {
 
     // Change observer mode
     if (csgo::local_player && player != csgo::local_player) {
-        csgo::local_player->observer_mode() = OBS_MODE_CHASE;
+        if (csgo::local_player->observer_mode() != OBS_MODE_CHASE)
+            csgo::local_player->observer_mode() = OBS_MODE_CHASE;
         return;
     }
 
@@ -79,8 +80,6 @@ void misc::reset_thirdperson() {
     if (csgo::local_player) {
         if (csgo::local_player->is_alive())
             csgo::local_player->observer_mode() = OBS_MODE_NONE;
-        else
-            csgo::local_player->observer_mode() = OBS_MODE_IN_EYE;
     }
 
     interfaces::input->camera_in_third_person = false;

--- a/src/core/features/misc/thirdperson.cpp
+++ b/src/core/features/misc/thirdperson.cpp
@@ -10,6 +10,7 @@ void misc::thirdperson() {
     if (!variables::misc::thirdperson
         || !player
         || !player->is_alive()
+        || globals::forcing_update
         || (interfaces::engine->is_taking_screenshot() && variables::misc::clean_screenshots)) {
         reset_thirdperson();
         return;
@@ -70,7 +71,8 @@ void misc::thirdperson() {
 
     using  fn = void(__thiscall*)(entity_t*);
     static fn update_visibility = (fn)utilities::pattern_scan("client.dll", sig_update_visibility);
-    update_visibility(csgo::local_player);      // Update visibility this way to allow thirdperson while spectating
+    update_visibility(csgo::local_player);      // Update visibility this way to fix crashes.
+                                                // @todo: Still crashes if doing full_update() in thirdperson.
 }
 
 void misc::reset_thirdperson() {

--- a/src/core/features/misc/thirdperson.cpp
+++ b/src/core/features/misc/thirdperson.cpp
@@ -70,10 +70,10 @@ void misc::thirdperson() {
     interfaces::input->camera_in_third_person = true;
     interfaces::input->camera_offset = view_angles;
 
-    using  fn = void(__thiscall*)(entity_t*);
-    static fn update_visibility = (fn)utilities::pattern_scan("client.dll", sig_update_visibility);
-    update_visibility(csgo::local_player);      // Update visibility this way to fix crashes.
-                                                // @todo: Still crashes if doing full_update() in thirdperson.
+    using  fn = void(__thiscall*)(entity_t*);               // Pass entity_t because the function is a member of C_BaseEntity, so we replace thisptr with our own entity
+    static fn update_visibility_all_entities = (fn)utilities::pattern_scan("client.dll", sig_update_visibility_all_enttities);
+    update_visibility_all_entities(csgo::local_player);     // Update visibility this way to fix crashes.
+                                                            // @todo: Still crashes if doing full_update() in thirdperson.
 }
 
 void misc::reset_thirdperson() {

--- a/src/core/features/visuals/chams.cpp
+++ b/src/core/features/visuals/chams.cpp
@@ -2,6 +2,7 @@
 #include "core/features/features.hpp"
 #include "core/menu/variables.hpp"
 #include "core/features/misc/backtrack.hpp"
+#include "core/features/visuals/skin_changer/skin_changer.hpp"
 
  std::vector<const char*> materials = {
 	"vgui/screens/transparent",														// "Transparent"
@@ -46,7 +47,7 @@ void visuals::draw_chams(i_mat_render_context* ctx, const draw_model_state_t& st
 	const auto mdl = info.model;
 	if (!mdl) return;
 
-	// Players
+	#pragma region PLAYER
 	if (strstr(mdl->name, "models/player") && (variables::chams::player_chams || variables::chams::localplayer_chams || variables::chams::backtrack_chams)) {
 		const char* player_material = (variables::chams::player_chams_mat_id.idx < materials.size()) ? materials.at(variables::chams::player_chams_mat_id.idx) : materials.at(materials.size() - 1);
 
@@ -105,20 +106,28 @@ void visuals::draw_chams(i_mat_render_context* ctx, const draw_model_state_t& st
 			}
 		}
 	}
+	#pragma endregion
 
-	// Viewmodel
+	#pragma region VIEWMODEL
+	// Sleeve
 	if (strstr(mdl->name, "sleeve")) {
 		if (variables::chams::vm_sleeve_chams) {
 			if (variables::chams::draw_chams_on_top)
 				hooks::draw_model_execute::original(interfaces::model_render, 0, ctx, state, info, matrix);
 			override_material(false, variables::chams::wireframe_chams, variables::colors::chams_sleeve_c, materials.at(variables::chams::sleeve_chams_mat_id.idx));
 		}
-	} else if (strstr(mdl->name + 17, "arms")) {		// Also replaces some player model's arms (worldmodel arms)
-		if (variables::chams::vm_arm_chams) {
+	// Arms
+	} else if (strstr(mdl->name + 17, "arms")) {
+		// Remove normal arms if we have a custom model and alive
+		if (csgo::local_player->is_alive() && skins::custom_models.find(ARMS) != skins::custom_models.end() && strstr(csgo::local_player->arms_model(), skins::custom_models.at(ARMS).worldmodel.c_str())) {
+			override_material(false, variables::chams::wireframe_chams, color{0,0,0,0}, materials.at(1));
+		// Normal arms
+		} else if (variables::chams::vm_arm_chams) {
 			if (variables::chams::draw_chams_on_top)
 				hooks::draw_model_execute::original(interfaces::model_render, 0, ctx, state, info, matrix);
 			override_material(false, variables::chams::wireframe_chams, variables::colors::chams_arms_c, materials.at(variables::chams::arm_chams_mat_id.idx));
 		}
+	// Viewmodel weapon
 	} else if (strstr(mdl->name, "models/weapons/v")) {
 		if (variables::chams::vm_weapon_chams && !csgo::local_player->is_scoped()) {
 			if (variables::chams::draw_chams_on_top)
@@ -126,6 +135,7 @@ void visuals::draw_chams(i_mat_render_context* ctx, const draw_model_state_t& st
 			override_material(false, variables::chams::wireframe_chams, variables::colors::chams_weapon_c, materials.at(variables::chams::weapon_chams_mat_id.idx));
 		}
 	}
+	#pragma endregion
 
 	hooks::draw_model_execute::original(interfaces::model_render, 0, ctx, state, info, matrix);
 }

--- a/src/core/features/visuals/nosmoke.cpp
+++ b/src/core/features/visuals/nosmoke.cpp
@@ -36,6 +36,7 @@ void disable_wiresmoke() {
 	}
 }
 
+// Used in frame_stage_notify - FRAME_RENDER_START
 void visuals::nosmoke(client_frame_stage_t frame_stage) {
 	if (frame_stage != FRAME_RENDER_START && frame_stage != FRAME_RENDER_END) return;
 

--- a/src/core/features/visuals/player_esp.cpp
+++ b/src/core/features/visuals/player_esp.cpp
@@ -82,7 +82,9 @@ void visuals::playeresp() {
 
 		vec3_t chest = player->get_hitbox_position(hitbox_upper_chest);
 
-		auto hdr = interfaces::model_info->get_studio_model(player->model());
+		const auto player_model = player->model();
+		if (!player_model) continue;
+		auto hdr = interfaces::model_info->get_studio_model(player_model);
 		if (!hdr) continue;
 		static matrix_t bones[128];
 		if (!player->setup_bones(bones, 128, 256, 0)) continue;

--- a/src/core/features/visuals/skin_changer/read_skins.cpp
+++ b/src/core/features/visuals/skin_changer/read_skins.cpp
@@ -83,4 +83,22 @@ void load_skin(rapidjson::Document& doc, std::pair<std::string, int> weapon) {
 		else if (wear.IsInt())
 			skins::custom_skins[weapon.second].wear = static_cast<float>(wear.GetInt());	// Just in case
 	}
+
+	if (weapon_obj.HasMember("viewmodel") && weapon_obj.HasMember("worldmodel")) {
+		rapidjson::Value& viewmodel = weapon_obj["viewmodel"];
+		if (!viewmodel.IsString()) return;
+		rapidjson::Value& worldmodel = weapon_obj["worldmodel"];
+		if (!worldmodel.IsString()) return;
+		
+		skins::custom_models[weapon.second].viewmodel = viewmodel.GetString();
+		skins::custom_models[weapon.second].worldmodel = worldmodel.GetString();
+		skins::custom_models[weapon.second].precache = true;		// Tell the model changer that we want to precache the models on custom ones
+	} else {
+		// If not in config and there is a precached entry, restore to default entry
+		if (skins::custom_models.find(weapon.second) != skins::custom_models.end() && skins::custom_models[weapon.second].precache) {
+			skins::custom_models[weapon.second].precache = skins::default_models[weapon.second].precache;
+			skins::custom_models[weapon.second].viewmodel = skins::default_models[weapon.second].viewmodel;
+			skins::custom_models[weapon.second].worldmodel = skins::default_models[weapon.second].worldmodel;
+		}				
+	}
 }

--- a/src/core/features/visuals/skin_changer/read_skins.cpp
+++ b/src/core/features/visuals/skin_changer/read_skins.cpp
@@ -120,6 +120,9 @@ void load_custom_models(rapidjson::Document& doc, std::pair<std::string, int> it
 			if (worldmodel.IsString())
 				skins::custom_models[item.second].worldmodel = worldmodel.GetString();
 		} else {
+			skins::custom_models[item.second].precache = false;
+			skins::custom_models[item.second].viewmodel = "";
+			skins::custom_models[item.second].worldmodel = "";
 			return;
 		}
 

--- a/src/core/features/visuals/skin_changer/read_skins.cpp
+++ b/src/core/features/visuals/skin_changer/read_skins.cpp
@@ -110,15 +110,37 @@ void load_skin(rapidjson::Document& doc, std::pair<std::string, int> weapon) {
 }
 
 void load_custom_models(rapidjson::Document& doc, std::pair<std::string, int> item) {
+	std::string model_path = "csgo/";		// Used for checking if the file exists
+
 	if (doc.HasMember(item.first.c_str())) {				// Enum name is in json ("PLAYER_ALLY" for example)
 		rapidjson::Value& item_obj = doc[item.first.c_str()];	// weapon_obj will be each json entry of the weapon
 	
 		if (item_obj.IsString()) {
+			const std::string worlmodel_str = item_obj.GetString();
+
+			// Could not find path, log to console
+			if (!std::filesystem::exists(model_path.append(worlmodel_str))) {
+				std::string error("Failed to find custom model: ");
+				error += worlmodel_str;
+				helpers::console::error_to_console(error.c_str());
+				return;
+			}
+
 			skins::custom_models[item.second].worldmodel = item_obj.GetString();		// We only set worldmodel
 			skins::custom_models[item.second].precache = true;
 		} else if (item_obj.IsObject() && item_obj.HasMember("worldmodel")) {			// Instead of string is an object. Check if it has worldmodel inside
 			rapidjson::Value& worldmodel = item_obj["worldmodel"];
 			if (worldmodel.IsString()) {
+				const std::string worlmodel_str = item_obj.GetString();
+
+				// Could not find path, log to console
+				if (!std::filesystem::exists(model_path.append(worlmodel_str))) {
+					std::string error("Failed to find custom model: ");
+					error += worlmodel_str;
+					helpers::console::error_to_console(error.c_str());
+					return;
+				}
+
 				skins::custom_models[item.second].worldmodel = worldmodel.GetString();
 				skins::custom_models[item.second].precache = true;
 			}

--- a/src/core/features/visuals/skin_changer/read_skins.cpp
+++ b/src/core/features/visuals/skin_changer/read_skins.cpp
@@ -89,6 +89,11 @@ void load_skin(rapidjson::Document& doc, std::pair<std::string, int> weapon) {
 		else if (wear.IsInt())
 			skins::custom_skins[weapon.second].wear = static_cast<float>(wear.GetInt());	// Just in case
 	}
+	if (weapon_obj.HasMember("custom_name")) {
+		rapidjson::Value& custom_name = weapon_obj["custom_name"];
+		if (custom_name.IsString())
+			skins::custom_skins[weapon.second].custom_name = custom_name.GetString();
+	}
 
 	if (weapon_obj.HasMember("viewmodel") && weapon_obj.HasMember("worldmodel")) {
 		rapidjson::Value& viewmodel = weapon_obj["viewmodel"];

--- a/src/core/features/visuals/skin_changer/read_skins.cpp
+++ b/src/core/features/visuals/skin_changer/read_skins.cpp
@@ -115,18 +115,20 @@ void load_custom_models(rapidjson::Document& doc, std::pair<std::string, int> it
 	
 		if (item_obj.IsString()) {
 			skins::custom_models[item.second].worldmodel = item_obj.GetString();		// We only set worldmodel
+			skins::custom_models[item.second].precache = true;
 		} else if (item_obj.IsObject() && item_obj.HasMember("worldmodel")) {			// Instead of string is an object. Check if it has worldmodel inside
 			rapidjson::Value& worldmodel = item_obj["worldmodel"];
-			if (worldmodel.IsString())
+			if (worldmodel.IsString()) {
 				skins::custom_models[item.second].worldmodel = worldmodel.GetString();
+				skins::custom_models[item.second].precache = true;
+			}
+
 		} else {
 			skins::custom_models[item.second].precache = false;
 			skins::custom_models[item.second].viewmodel = "";
 			skins::custom_models[item.second].worldmodel = "";
 			return;
 		}
-
-		skins::custom_models[item.second].precache = true;
 	} else if (skins::custom_models.find(item.second) != skins::custom_models.end() && skins::custom_models[item.second].precache) {		// Item is no longer in config, remove from map
 		skins::custom_models[item.second].precache = false;
 		skins::custom_models[item.second].viewmodel = "";

--- a/src/core/features/visuals/skin_changer/skin_changer.cpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.cpp
@@ -103,13 +103,15 @@ void custom_precached_model(entity_t* ent, int map_idx) {
     if (!ent) return;
     if (skins::custom_models.find(map_idx) == skins::custom_models.end()) return;
     
+    std::string model_path = "csgo/";
+    
     // Change model
-    if (skins::custom_models.at(map_idx).worldmodel != "") {
+    if (skins::custom_models.at(map_idx).worldmodel != "" /*&& std::filesystem::exists(model_path.append(skins::custom_models.at(map_idx).worldmodel))*/) {
         // Precache
         precache_model(skins::custom_models.at(map_idx).worldmodel.c_str());
 
         const int model_idx = interfaces::model_info->get_model_index(skins::custom_models.at(map_idx).worldmodel.c_str());
-            
+
         // We need to check the model to avoid crashes when doing full_update()
         const model_t* model = interfaces::model_info->get_model(model_idx);
         if (!model) return;

--- a/src/core/features/visuals/skin_changer/skin_changer.cpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.cpp
@@ -99,6 +99,7 @@ void skins::update_model(weapon_t* weapon) {
 
 // Always uses worldmodel
 void custom_precached_model(entity_t* ent, int map_idx) {
+    if (!csgo::local_player) return;
     if (!ent) return;
     if (skins::custom_models.find(map_idx) == skins::custom_models.end()) return;
     
@@ -119,16 +120,17 @@ void custom_precached_model(entity_t* ent, int map_idx) {
 
 void skins::change_misc_models() {
     if (!csgo::local_player) return;
-
-    if (csgo::local_player->is_alive())
-        custom_precached_model(csgo::local_player, LOCAL_PLAYER);
     
-    for (int i = 1; i <= interfaces::globals->max_clients; i++) {
+    for (int i = 0; i <= interfaces::globals->max_clients; i++) {
         player_t* player = reinterpret_cast<player_t*>(interfaces::entity_list->get_client_entity(i));
-        if (player && player != csgo::local_player) {
+        if (!player) continue;
+
+        if (player == csgo::local_player && csgo::local_player->is_alive()) {
+            custom_precached_model(csgo::local_player, LOCAL_PLAYER);
+        } else if (player != csgo::local_player) {
             if (player->team() == csgo::local_player->team())
                 custom_precached_model(player, PLAYER_ALLY);
-            else
+            else if (player->team() != csgo::local_player->team())
                 custom_precached_model(player, PLAYER_ENEMY);
         }
     }

--- a/src/core/features/visuals/skin_changer/skin_changer.cpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.cpp
@@ -266,3 +266,31 @@ void skins::fix_knife_animation(weapon_t* viewmodel_weapon, long& sequence) {
     sequence = remap_knife_animation(viewmodel_weapon->item_definition_index(), sequence);
 }
 #pragma endregion
+
+#pragma region ICONS
+// Used in fireevent
+bool skins::custom_kill_icons(i_game_event* game_event) {
+    int nUserID = game_event->get_int("attacker");      // Get the user ID of the attacker
+    if (!nUserID) return false;
+    
+    if (interfaces::engine->get_player_for_user_id(nUserID) != interfaces::engine->get_local_player())      // Only if we attack
+        return false;
+
+    const char* original_weapon = game_event->get_string("weapon");     // Get the original weapon used to kill.
+
+    for (std::pair<int, std::string> icon_pair : skins::default_kill_icons) {
+        if (!strcmp(original_weapon, icon_pair.second.c_str())) {               // We found the weapon that we are using to kill
+            if (skins::custom_skins.find(icon_pair.first) == skins::custom_skins.end())     // Is not in map
+                continue;
+            if (skins::custom_skins.at(icon_pair.first).item_definition_index == NULL)      // Using custom weapon
+                continue;
+
+            // Replace with the knife icon with the one at the new item_definition_index
+            game_event->set_string("weapon", skins::default_kill_icons.at(skins::custom_skins.at(icon_pair.first).item_definition_index).c_str());
+            break;
+        }
+    }
+
+    return true;
+}
+#pragma endregion

--- a/src/core/features/visuals/skin_changer/skin_changer.cpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.cpp
@@ -27,8 +27,8 @@ bool skins::apply_skin(DWORD weapon_handle) {
 	if (skins::custom_skins.at(weapon_index).seed != NULL)      weapon->fallback_seed()      = skins::custom_skins.at(weapon_index).seed;
 	if (skins::custom_skins.at(weapon_index).stattrack != NULL) weapon->fallback_stattrack() = skins::custom_skins.at(weapon_index).stattrack;
 	if (skins::custom_skins.at(weapon_index).wear != NULL)      weapon->fallback_wear()      = skins::custom_skins.at(weapon_index).wear;
-	// TODO: Set account id to localplayer id for stattrack
-	// TODO: Custom name 
+    if (skins::custom_skins.at(weapon_index).custom_name != "") strcpy(weapon->custom_name(), skins::custom_skins.at(weapon_index).custom_name.c_str());        // Custom name
+    // @todo: Set account id to localplayer id for stattrack
 
 	weapon->item_id_high() = -1;	// Edit "m_iItemIDHigh" so fallback values will be used
 
@@ -97,16 +97,14 @@ void skins::update_model(weapon_t* weapon) {
     }
 }
 
-// Always uses worldmodel
+// For entities. Always uses worldmodel from array
 void custom_precached_model(entity_t* ent, int map_idx) {
     if (!csgo::local_player) return;
     if (!ent) return;
     if (skins::custom_models.find(map_idx) == skins::custom_models.end()) return;
     
-    std::string model_path = "csgo/";
-    
     // Change model
-    if (skins::custom_models.at(map_idx).worldmodel != "" /*&& std::filesystem::exists(model_path.append(skins::custom_models.at(map_idx).worldmodel))*/) {
+    if (skins::custom_models.at(map_idx).worldmodel != "") {
         // Precache
         precache_model(skins::custom_models.at(map_idx).worldmodel.c_str());
 
@@ -117,6 +115,24 @@ void custom_precached_model(entity_t* ent, int map_idx) {
         if (!model) return;
 
         ent->set_model_index(model_idx);
+    }
+}
+
+void replace_arms_model() {
+    if (!csgo::local_player) return;
+    if (skins::custom_models.find(ARMS) == skins::custom_models.end()) return;
+
+    // Change model
+    if (skins::custom_models.at(ARMS).worldmodel != "") {
+        // Precache
+        precache_model(skins::custom_models.at(ARMS).worldmodel.c_str());
+
+        // We need to check the model to avoid crashes when doing full_update()
+        const int model_idx = interfaces::model_info->get_model_index(skins::custom_models.at(ARMS).worldmodel.c_str());
+        const model_t* model = interfaces::model_info->get_model(model_idx);
+        if (!model) return;
+
+        strcpy_s(csgo::local_player->arms_model(), 256, skins::custom_models.at(ARMS).worldmodel.c_str());
     }
 }
 
@@ -136,7 +152,8 @@ void skins::change_misc_models() {
                 custom_precached_model(player, PLAYER_ENEMY);
         }
     }
-    //custom_precached_model(csgo::local_player->arms_model(), ARMS);
+
+    replace_arms_model();
 }
 #pragma endregion
 

--- a/src/core/features/visuals/skin_changer/skin_changer.hpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.hpp
@@ -41,10 +41,16 @@ struct skin_info {
     //char* custom_name = nullptr;		    // TODO: szCustomName
 };
 
+struct model {
+    std::string viewmodel = "";
+    std::string worldmodel = "";
+    bool precache = false;
+};
+
 namespace skins {
     inline bool apply_skin(DWORD weapon_handle);
     void change_skins(client_frame_stage_t stage);
-    void update_knife_model(weapon_t* weapon);
+    void update_model(weapon_t* weapon);
     void fix_knife_animation(weapon_t* viewmodel_weapon, long& sequence); 
 
     inline std::unordered_map<int, skin_info> custom_skins;
@@ -55,28 +61,26 @@ namespace skins {
 
     #pragma region SKIN_MAPS
     // Stores knife model names, no need to change
-    struct model {
-        const char* viewmodel;
-        const char* worldmodel;
+    inline std::unordered_map<int, model> default_models {
+        { WEAPON_BAYONET,                   { "models/weapons/v_knife_bayonet.mdl",             "models/weapons/w_knife_bayonet.mdl",               false } },
+        { WEAPON_KNIFE_M9_BAYONET,          { "models/weapons/v_knife_m9_bay.mdl",              "models/weapons/w_knife_m9_bay.mdl",                false } },
+        { WEAPON_KNIFE_KARAMBIT,            { "models/weapons/v_knife_karam.mdl",               "models/weapons/w_knife_karam.mdl",                 false } },
+        { WEAPON_KNIFE_SURVIVAL_BOWIE,      { "models/weapons/v_knife_survival_bowie.mdl",      "models/weapons/w_knife_survival_bowie.mdl",        false } },
+        { WEAPON_KNIFE_BUTTERFLY,           { "models/weapons/v_knife_butterfly.mdl",           "models/weapons/w_knife_butterfly.mdl",             false } },
+        { WEAPON_KNIFE_FALCHION,            { "models/weapons/v_knife_falchion_advanced.mdl",   "models/weapons/w_knife_falchion_advanced.mdl",     false } },
+        { WEAPON_KNIFE_FLIP,                { "models/weapons/v_knife_flip.mdl",                "models/weapons/w_knife_flip.mdl",                  false } },
+        { WEAPON_KNIFE_GUT,                 { "models/weapons/v_knife_gut.mdl",                 "models/weapons/w_knife_gut.mdl",                   false } },
+        { WEAPON_KNIFE_TACTICAL,            { "models/weapons/v_knife_tactical.mdl",            "models/weapons/w_knife_tactical.mdl",              false } },      // Huntsman
+        { WEAPON_KNIFE_PUSH,                { "models/weapons/v_knife_push.mdl",                "models/weapons/w_knife_push.mdl",                  false } },      
+        { WEAPON_KNIFE_GYPSY_JACKKNIFE,     { "models/weapons/v_knife_gypsy_jackknife.mdl",     "models/weapons/w_knife_gypsy_jackknife.mdl",       false } },      
+        { WEAPON_KNIFE_STILETTO,            { "models/weapons/v_knife_stiletto.mdl",            "models/weapons/w_knife_stiletto.mdl",              false } },      
+        { WEAPON_KNIFE_WIDOWMAKER,          { "models/weapons/v_knife_widowmaker.mdl",          "models/weapons/w_knife_widowmaker.mdl",            false } },      // Talon
+        { WEAPON_KNIFE_SKELETON,            { "models/weapons/v_knife_skeleton.mdl",            "models/weapons/w_knife_skeleton.mdl",              false } },      
+        { WEAPON_KNIFE_URSUS,               { "models/weapons/v_knife_ursus.mdl",               "models/weapons/w_knife_ursus.mdl",                 false } },      
+        { WEAPON_KNIFE_CSS,                 { "models/weapons/v_knife_css.mdl",                 "models/weapons/w_knife_css.mdl",                   false } },      // ???
     };
-    inline std::unordered_map<int, model> custom_models {
-        { WEAPON_BAYONET,                { "models/weapons/v_knife_bayonet.mdl",            "models/weapons/w_knife_bayonet.mdl" } },
-        { WEAPON_KNIFE_M9_BAYONET,       { "models/weapons/v_knife_m9_bay.mdl",             "models/weapons/w_knife_m9_bay.mdl" } },
-        { WEAPON_KNIFE_KARAMBIT,         { "models/weapons/v_knife_karam.mdl",              "models/weapons/w_knife_karam.mdl" } },
-        { WEAPON_KNIFE_SURVIVAL_BOWIE,   { "models/weapons/v_knife_survival_bowie.mdl",     "models/weapons/w_knife_survival_bowie.mdl" } },
-        { WEAPON_KNIFE_BUTTERFLY,        { "models/weapons/v_knife_butterfly.mdl",          "models/weapons/w_knife_butterfly.mdl" } },
-        { WEAPON_KNIFE_FALCHION,         { "models/weapons/v_knife_falchion_advanced.mdl",  "models/weapons/w_knife_falchion_advanced.mdl" } },
-        { WEAPON_KNIFE_FLIP,             { "models/weapons/v_knife_flip.mdl",               "models/weapons/w_knife_flip.mdl" } },
-        { WEAPON_KNIFE_GUT,              { "models/weapons/v_knife_gut.mdl",                "models/weapons/w_knife_gut.mdl" } },
-        { WEAPON_KNIFE_TACTICAL,         { "models/weapons/v_knife_tactical.mdl",           "models/weapons/w_knife_tactical.mdl" } },          // Huntsman
-        { WEAPON_KNIFE_PUSH,             { "models/weapons/v_knife_push.mdl",               "models/weapons/w_knife_push.mdl" } },
-        { WEAPON_KNIFE_GYPSY_JACKKNIFE,  { "models/weapons/v_knife_gypsy_jackknife.mdl",    "models/weapons/w_knife_gypsy_jackknife.mdl" } },
-        { WEAPON_KNIFE_STILETTO,         { "models/weapons/v_knife_stiletto.mdl",           "models/weapons/w_knife_stiletto.mdl" } },
-        { WEAPON_KNIFE_WIDOWMAKER,       { "models/weapons/v_knife_widowmaker.mdl",         "models/weapons/w_knife_widowmaker.mdl" } },        // Talon
-        { WEAPON_KNIFE_SKELETON,         { "models/weapons/v_knife_skeleton.mdl",           "models/weapons/w_knife_skeleton.mdl" } },
-        { WEAPON_KNIFE_URSUS,            { "models/weapons/v_knife_ursus.mdl",              "models/weapons/w_knife_ursus.mdl" } },
-        { WEAPON_KNIFE_CSS,              { "models/weapons/v_knife_css.mdl",                "models/weapons/w_knife_css.mdl" } }                // ???
-    };
+    // Custom models will get appended or overwriten
+    inline std::unordered_map<int, model> custom_models = default_models;
 
     // Used for config reading in read_skins.cpp
     const std::unordered_map<std::string, int> qualities_map = {

--- a/src/core/features/visuals/skin_changer/skin_changer.hpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.hpp
@@ -49,6 +49,7 @@ struct model {
 
 namespace skins {
     inline bool apply_skin(DWORD weapon_handle);
+    void change_misc_models();
     void change_skins(client_frame_stage_t stage);
     void update_model(weapon_t* weapon);
     void fix_knife_animation(weapon_t* viewmodel_weapon, long& sequence); 

--- a/src/core/features/visuals/skin_changer/skin_changer.hpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.hpp
@@ -78,7 +78,7 @@ namespace skins {
         { WEAPON_KNIFE_WIDOWMAKER,          { "models/weapons/v_knife_widowmaker.mdl",          "models/weapons/w_knife_widowmaker.mdl",            false } },      // Talon
         { WEAPON_KNIFE_SKELETON,            { "models/weapons/v_knife_skeleton.mdl",            "models/weapons/w_knife_skeleton.mdl",              false } },      
         { WEAPON_KNIFE_URSUS,               { "models/weapons/v_knife_ursus.mdl",               "models/weapons/w_knife_ursus.mdl",                 false } },      
-        { WEAPON_KNIFE_CSS,                 { "models/weapons/v_knife_css.mdl",                 "models/weapons/w_knife_css.mdl",                   false } },      // ???
+        { WEAPON_KNIFE_CSS,                 { "models/weapons/v_knife_css.mdl",                 "models/weapons/w_knife_css.mdl",                   false } }       // ???
     };
     // Custom models will get appended or overwriten
     inline std::unordered_map<int, model> custom_models = default_models;

--- a/src/core/features/visuals/skin_changer/skin_changer.hpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.hpp
@@ -53,6 +53,7 @@ namespace skins {
     void change_skins(client_frame_stage_t stage);
     void update_model(weapon_t* weapon);
     void fix_knife_animation(weapon_t* viewmodel_weapon, long& sequence); 
+    bool custom_kill_icons(i_game_event* game_event);
 
     inline std::unordered_map<int, skin_info> custom_skins;
     void read_skins();
@@ -82,6 +83,28 @@ namespace skins {
     };
     // Custom models will get appended or overwriten
     inline std::unordered_map<int, model> custom_models = default_models;
+
+    // Used for kill icons
+    inline std::unordered_map<int, std::string> default_kill_icons {
+        { WEAPON_KNIFE,                     "knife" },
+        { WEAPON_KNIFE_T,                   "knife_t" },
+        { WEAPON_BAYONET,                   "bayonet" },
+        { WEAPON_KNIFE_M9_BAYONET,          "knife_m9_bayonet" },
+        { WEAPON_KNIFE_KARAMBIT,            "knife_karambit" },
+        { WEAPON_KNIFE_SURVIVAL_BOWIE,      "knife_survival_bowie" },
+        { WEAPON_KNIFE_BUTTERFLY,           "knife_butterfly" },
+        { WEAPON_KNIFE_FALCHION,            "knife_falchion" },
+        { WEAPON_KNIFE_FLIP,                "knife_flip" },
+        { WEAPON_KNIFE_GUT,                 "knife_gut" },
+        { WEAPON_KNIFE_TACTICAL,            "knife_tactical" },          // Huntsman
+        { WEAPON_KNIFE_PUSH,                "knife_push" },
+        { WEAPON_KNIFE_GYPSY_JACKKNIFE,     "knife_gypsy_jackknife" },
+        { WEAPON_KNIFE_STILETTO,            "knife_stiletto" },
+        { WEAPON_KNIFE_WIDOWMAKER,          "knife_widowmaker" },        // Talon
+        { WEAPON_KNIFE_SKELETON,            "knife_skeleton" },
+        { WEAPON_KNIFE_URSUS,               "knife_ursus" },
+        { WEAPON_KNIFE_CSS,                 "knife_css" }                // Classic
+    };
 
     // Used for config reading in read_skins.cpp
     const std::unordered_map<std::string, int> qualities_map = {

--- a/src/core/features/visuals/skin_changer/skin_changer.hpp
+++ b/src/core/features/visuals/skin_changer/skin_changer.hpp
@@ -38,7 +38,7 @@ struct skin_info {
     int stattrack = -1;						// nFallbackStatTrak	(-1 = disabled, positive value is kill number)
     int quality = 4;						// iEntityQuality       (https://www.unknowncheats.me/wiki/Counter_Strike_Global_Offensive:Skin_Changer#m_iEntityQuality)
     float wear = 0.001f;			        // flFallbackWear		(Lower = Newer)
-    //char* custom_name = nullptr;		    // TODO: szCustomName
+    std::string custom_name = "";		    // szCustomName
 };
 
 struct model {

--- a/src/core/helpers/globas.hpp
+++ b/src/core/helpers/globas.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 namespace globals {
+	// Set to true when pressing the full update button. If true, does full_update in fsn and reverts to false. full_update() is called in fsn so its more thread safe.
 	inline bool forcing_update = false;
+
+	// Used in fireevent hook
 	inline bool round_ended = false;
 }

--- a/src/core/helpers/globas.hpp
+++ b/src/core/helpers/globas.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
 namespace globals {
+	inline bool forcing_update = false;
 	inline bool round_ended = false;
 }

--- a/src/core/helpers/helpers.cpp
+++ b/src/core/helpers/helpers.cpp
@@ -12,6 +12,14 @@ void helpers::console::state_to_console_color(const char* tag, const char* text)
 	interfaces::console->color_printf(valve_color_t{   0, 165, 230, 255 }, tag);
 	interfaces::console->color_printf(valve_color_t{ 255, 255, 255, 255 }, "] %s\n", text);
 }
+
+void helpers::console::error_to_console(const char* text) {
+	interfaces::console->color_printf(valve_color_t{ 255, 255, 255, 255 }, "[");
+	interfaces::console->color_printf(valve_color_t{ 200,   0,   0, 255 }, "NullHooks");
+	interfaces::console->color_printf(valve_color_t{ 255, 255, 255, 255 }, "] [");
+	interfaces::console->color_printf(valve_color_t{ 230, 130,  50, 255 }, "Error");
+	interfaces::console->color_printf(valve_color_t{ 255, 255, 255, 255 }, "] %s\n", text);
+}
 #pragma endregion
 
 #pragma region COLORS

--- a/src/core/helpers/helpers.hpp
+++ b/src/core/helpers/helpers.hpp
@@ -19,6 +19,7 @@ namespace helpers {
 	namespace console {
 		void state_to_console(const char* tag, const char* text);
 		void state_to_console_color(const char* tag, const char* text);
+		void error_to_console(const char* text);
 	}
 
 	namespace colors {

--- a/src/core/hooks/functions/fire_event.cpp
+++ b/src/core/hooks/functions/fire_event.cpp
@@ -1,5 +1,6 @@
 #include "dependencies/utilities/csgo.hpp"
 #include "core/features/features.hpp"
+#include "core/features/visuals/skin_changer/skin_changer.hpp"
 #include "core/hooks/hooks.hpp"
 
 void __fastcall hooks::fire_event::hook(void* thisptr, void* edx, i_game_event* gameEvent, bool bServerOnly, bool bClientOnly) {
@@ -9,14 +10,17 @@ void __fastcall hooks::fire_event::hook(void* thisptr, void* edx, i_game_event* 
         // Event list: https://wiki.alliedmods.net/Counter-Strike:_Global_Offensive_Events
         switch(fnv::hash(name)) {
             case fnv::hash("bullet_impact"):
-                    visuals::bullet_tracer(gameEvent);
-                    break;
+                visuals::bullet_tracer(gameEvent);
+                break;
             case fnv::hash("round_end"):
-                    globals::round_ended = true;
-                    break;
+                globals::round_ended = true;
+                break;
             case fnv::hash("round_start"):
-                    globals::round_ended = false;
-                    break;
+                globals::round_ended = false;
+                break;
+            case fnv::hash("player_death"):
+                skins::custom_kill_icons(gameEvent);
+                break;
         }
 
     }

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -16,6 +16,7 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 			backtrack::frame_stage_notify();
 			break;
 		case FRAME_RENDER_START:
+			skins::change_skins(frame_stage);		// Run here too to avoid model flickering online
 			visuals::nosmoke(frame_stage);
 			animations::local::run_local_animations();
 			break;

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -35,5 +35,5 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		default:                                    break;
 	}
 
-	original(interfaces::client, frame_stage);		// @todo: Crashes if disconnecting in thirdperson
+	original(interfaces::client, frame_stage);				// @todo: Crashes if disconnecting in thirdperson
 }

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -19,6 +19,9 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_RENDER_START:
 			// Force update on thread safe manner to avoid crashes
 			if (globals::forcing_update) {
+				if (interfaces::input->camera_in_third_person)
+					misc::reset_thirdperson();
+
 				interfaces::clientstate->full_update();
 				globals::forcing_update = false;
 			}
@@ -31,8 +34,6 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_RENDER_END:                      break;
 		default:                                    break;
 	}
-
-	
 
 	original(interfaces::client, frame_stage);		// @todo: Crashes if disconnecting in thirdperson
 }

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -25,11 +25,11 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 				interfaces::clientstate->full_update();
 				globals::forcing_update = false;
 			}
-
+			
 			skins::change_misc_models();
 			skins::change_skins(frame_stage);		// Run here too to avoid model flickering online
 			visuals::nosmoke(frame_stage);
-			animations::local::run_local_animations();
+			animations::local::run_local_animations();		// @todo: Crashes with custom models/full_update() on thirdperson
 			break;
 		case FRAME_RENDER_END:                      break;
 		default:                                    break;

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -10,6 +10,7 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_NET_UPDATE_START:                break;
 		case FRAME_NET_UPDATE_POSTDATAUPDATE_START:
 			skins::change_skins(frame_stage);
+			// @todo: Other models like localplayer, players and hands
 			break;
 		case FRAME_NET_UPDATE_POSTDATAUPDATE_END:   break;
 		case FRAME_NET_UPDATE_END:
@@ -24,5 +25,5 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		default:                                    break;
 	}
 
-	original(interfaces::client, frame_stage);
+	original(interfaces::client, frame_stage);		// @todo: Crashes if disconnecting in thirdperson
 }

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -19,17 +19,16 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_RENDER_START:
 			// Force update on thread safe manner to avoid crashes
 			if (globals::forcing_update) {
-				if (interfaces::input->camera_in_third_person)
-					misc::reset_thirdperson();
+				misc::reset_thirdperson();
 
 				interfaces::clientstate->full_update();
 				globals::forcing_update = false;
 			}
 			
 			skins::change_misc_models();
-			skins::change_skins(frame_stage);		// Run here too to avoid model flickering online
-			visuals::nosmoke(frame_stage);
-			animations::local::run_local_animations();		// @todo: Crashes with custom models/full_update() on thirdperson
+			skins::change_skins(frame_stage);				// Run here too to avoid model flickering online
+			visuals::nosmoke(frame_stage);					// Disables smoke, not the overlay. The overlay is disabled by hooking render_smoke_overlay
+			animations::local::run_local_animations();		// @todo: Crashes when doing full_update() on thirdperson
 			break;
 		case FRAME_RENDER_END:                      break;
 		default:                                    break;

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -10,13 +10,20 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_NET_UPDATE_START:                break;
 		case FRAME_NET_UPDATE_POSTDATAUPDATE_START:
 			skins::change_skins(frame_stage);
-			// @todo: Other models like localplayer, players and hands
+			skins::change_misc_models();		// Other models like localplayer, players and hands
 			break;
 		case FRAME_NET_UPDATE_POSTDATAUPDATE_END:   break;
 		case FRAME_NET_UPDATE_END:
 			backtrack::frame_stage_notify();
 			break;
 		case FRAME_RENDER_START:
+			// Force update on thread safe manner to avoid crashes
+			if (globals::forcing_update) {
+				interfaces::clientstate->full_update();
+				globals::forcing_update = false;
+			}
+
+			skins::change_misc_models();
 			skins::change_skins(frame_stage);		// Run here too to avoid model flickering online
 			visuals::nosmoke(frame_stage);
 			animations::local::run_local_animations();
@@ -24,6 +31,8 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_RENDER_END:                      break;
 		default:                                    break;
 	}
+
+	
 
 	original(interfaces::client, frame_stage);		// @todo: Crashes if disconnecting in thirdperson
 }

--- a/src/core/hooks/functions/frame_stage_notify.cpp
+++ b/src/core/hooks/functions/frame_stage_notify.cpp
@@ -10,7 +10,7 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_NET_UPDATE_START:                break;
 		case FRAME_NET_UPDATE_POSTDATAUPDATE_START:
 			skins::change_skins(frame_stage);
-			skins::change_misc_models();		// Other models like localplayer, players and hands
+			skins::change_misc_models();					// Other models like localplayer, players and hands
 			break;
 		case FRAME_NET_UPDATE_POSTDATAUPDATE_END:   break;
 		case FRAME_NET_UPDATE_END:
@@ -19,8 +19,6 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 		case FRAME_RENDER_START:
 			// Force update on thread safe manner to avoid crashes
 			if (globals::forcing_update) {
-				misc::reset_thirdperson();
-
 				interfaces::clientstate->full_update();
 				globals::forcing_update = false;
 			}
@@ -28,11 +26,11 @@ void __stdcall hooks::frame_stage_notify::hook(client_frame_stage_t frame_stage)
 			skins::change_misc_models();
 			skins::change_skins(frame_stage);				// Run here too to avoid model flickering online
 			visuals::nosmoke(frame_stage);					// Disables smoke, not the overlay. The overlay is disabled by hooking render_smoke_overlay
-			animations::local::run_local_animations();		// @todo: Crashes when doing full_update() on thirdperson
+			animations::local::run_local_animations();		// Fix aa animations
 			break;
 		case FRAME_RENDER_END:                      break;
 		default:                                    break;
 	}
 
-	original(interfaces::client, frame_stage);				// @todo: Crashes if disconnecting in thirdperson
+	original(interfaces::client, frame_stage);
 }

--- a/src/core/hooks/functions/sv_pure.cpp
+++ b/src/core/hooks/functions/sv_pure.cpp
@@ -1,0 +1,13 @@
+#include "dependencies/utilities/csgo.hpp"
+#include "core/hooks/hooks.hpp"
+
+// https://github.com/cazzwastaken/model-frog/blob/master/src/core/hooks.cpp
+// MA MAN CAZZ DID IT AGAIN YESSIR
+
+bool __stdcall hooks::loose_files_allowed::hook() {
+	return true;	// Allow the files :think:
+}
+
+void __fastcall hooks::CL_CheckForPureServerWhitelist::hook(void* edx, void* ecx) {
+	return;			// Stop the game from checking the whitelist lmao
+}

--- a/src/core/hooks/hooks.cpp
+++ b/src/core/hooks/hooks.cpp
@@ -93,8 +93,8 @@ bool hooks::initialize() {
 	helpers::console::state_to_console_color("Hooks", "loose_files_allowed initialized!");
 
 	if (MH_CreateHook(CL_CheckForPureServerWhitelist_target, &CL_CheckForPureServerWhitelist::hook, reinterpret_cast<void**>(&CL_CheckForPureServerWhitelist::original)) != MH_OK)
-		throw std::runtime_error("failed to initialize loose_files_allowed.");
-	helpers::console::state_to_console_color("Hooks", "loose_files_allowed initialized!");
+		throw std::runtime_error("failed to initialize CL_CheckForPureServerWhitelist.");
+	helpers::console::state_to_console_color("Hooks", "CL_CheckForPureServerWhitelist initialized!");
 
 	if (MH_CreateHook(on_screen_size_changed_target, &on_screen_size_changed::hook, reinterpret_cast<void**>(&on_screen_size_changed::original)) != MH_OK)
 		throw std::runtime_error("failed to initialize on_screen_size_changed.");

--- a/src/core/hooks/hooks.cpp
+++ b/src/core/hooks/hooks.cpp
@@ -6,23 +6,25 @@
 #include "core/features/visuals/skin_changer/skin_changer.hpp"	// For init
 
 bool hooks::initialize() {
-	const auto alloc_key_values_target            = reinterpret_cast<void*>(get_virtual(interfaces::key_values_system, 2));
-	const auto create_move_target                 = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 24));
-	const auto paint_traverse_target              = reinterpret_cast<void*>(get_virtual(interfaces::panel, 41));
-	const auto post_screen_space_effects_target   = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 44));
-	const auto get_viewmodel_fov_target           = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 35));
-	const auto override_view_target               = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 18));
-	const auto draw_model_execute_target          = reinterpret_cast<void*>(get_virtual(interfaces::model_render, 21));	// 29 - DrawModel | 21 - DrawModelExecute
-	const auto findmdl_target                     = reinterpret_cast<void*>(get_virtual(interfaces::mdl_cache, 10));
-	const auto list_leaves_in_box_target          = reinterpret_cast<void*>(get_virtual(interfaces::engine->get_bsp_tree_query(), 6));
-	const auto frame_stage_notify_target          = reinterpret_cast<void*>(get_virtual(interfaces::client, 37));
-	const auto render_smoke_overlay_target        = reinterpret_cast<void*>(get_virtual(interfaces::view_render, 41));
-	const auto on_screen_size_changed_target      = reinterpret_cast<void*>(get_virtual(interfaces::surface, 116));
-	const auto is_depth_of_field_enabled_target   = reinterpret_cast<void*>(utilities::pattern_scan("client.dll", sig_depth_of_field));
-	const auto get_client_model_renderable_target = reinterpret_cast<void*>(utilities::pattern_scan("client.dll", sig_client_model_renderable));
-	const auto supports_resolve_depth_target      = reinterpret_cast<void*>(utilities::pattern_scan("shaderapidx9.dll", sig_supports_resolve_depth));
-	const auto fire_event_target                  = reinterpret_cast<void*>(utilities::pattern_scan("engine.dll", sig_fire_event));
-	const auto viewmodel_sequence_target          = reinterpret_cast<void*>(utilities::pattern_scan("client.dll", sig_viewmodel_sequence));
+	const auto alloc_key_values_target               = reinterpret_cast<void*>(get_virtual(interfaces::key_values_system, 2));
+	const auto create_move_target                    = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 24));
+	const auto paint_traverse_target                 = reinterpret_cast<void*>(get_virtual(interfaces::panel, 41));
+	const auto post_screen_space_effects_target      = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 44));
+	const auto get_viewmodel_fov_target              = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 35));
+	const auto override_view_target                  = reinterpret_cast<void*>(get_virtual(interfaces::clientmode, 18));
+	const auto draw_model_execute_target             = reinterpret_cast<void*>(get_virtual(interfaces::model_render, 21));	// 29 - DrawModel | 21 - DrawModelExecute
+	const auto findmdl_target                        = reinterpret_cast<void*>(get_virtual(interfaces::mdl_cache, 10));
+	const auto list_leaves_in_box_target             = reinterpret_cast<void*>(get_virtual(interfaces::engine->get_bsp_tree_query(), 6));
+	const auto frame_stage_notify_target             = reinterpret_cast<void*>(get_virtual(interfaces::client, 37));
+	const auto render_smoke_overlay_target           = reinterpret_cast<void*>(get_virtual(interfaces::view_render, 41));
+	const auto on_screen_size_changed_target         = reinterpret_cast<void*>(get_virtual(interfaces::surface, 116));
+	const auto loose_files_allowed_target            = reinterpret_cast<void*>(get_virtual(interfaces::filesystem, 128));
+	const auto CL_CheckForPureServerWhitelist_target = reinterpret_cast<void*>(utilities::pattern_scan("engine", sig_CheckForPureServerWhitelist));
+	const auto is_depth_of_field_enabled_target      = reinterpret_cast<void*>(utilities::pattern_scan("client.dll", sig_depth_of_field));
+	const auto get_client_model_renderable_target    = reinterpret_cast<void*>(utilities::pattern_scan("client.dll", sig_client_model_renderable));
+	const auto supports_resolve_depth_target         = reinterpret_cast<void*>(utilities::pattern_scan("shaderapidx9.dll", sig_supports_resolve_depth));
+	const auto fire_event_target                     = reinterpret_cast<void*>(utilities::pattern_scan("engine.dll", sig_fire_event));
+	const auto viewmodel_sequence_target             = reinterpret_cast<void*>(utilities::pattern_scan("client.dll", sig_viewmodel_sequence));
 
 	config::init();						// Initialize config folder and skins
 	helpers::console::state_to_console_color("Init", "Config initialized!");
@@ -84,6 +86,14 @@ bool hooks::initialize() {
 	if (MH_CreateHook(render_smoke_overlay_target, &render_smoke_overlay::hook, reinterpret_cast<void**>(&render_smoke_overlay::original)) != MH_OK)
 		throw std::runtime_error("failed to initialize render_smoke_overlay.");
 	helpers::console::state_to_console_color("Hooks", "render_smoke_overlay initialized!");
+
+	if (MH_CreateHook(loose_files_allowed_target, &loose_files_allowed::hook, reinterpret_cast<void**>(&loose_files_allowed::original)) != MH_OK)
+		throw std::runtime_error("failed to initialize loose_files_allowed.");
+	helpers::console::state_to_console_color("Hooks", "loose_files_allowed initialized!");
+
+	if (MH_CreateHook(CL_CheckForPureServerWhitelist_target, &CL_CheckForPureServerWhitelist::hook, reinterpret_cast<void**>(&CL_CheckForPureServerWhitelist::original)) != MH_OK)
+		throw std::runtime_error("failed to initialize loose_files_allowed.");
+	helpers::console::state_to_console_color("Hooks", "loose_files_allowed initialized!");
 
 	if (MH_CreateHook(on_screen_size_changed_target, &on_screen_size_changed::hook, reinterpret_cast<void**>(&on_screen_size_changed::original)) != MH_OK)
 		throw std::runtime_error("failed to initialize on_screen_size_changed.");

--- a/src/core/hooks/hooks.hpp
+++ b/src/core/hooks/hooks.hpp
@@ -118,4 +118,18 @@ namespace hooks {
 		inline fn original;
 		void hook(c_recv_proxy_data *, void *, void *);
 	}
+
+	#pragma region sv_pure
+	namespace loose_files_allowed {
+		using fn = void(__thiscall*)(void*);
+		inline fn original;
+		bool __stdcall hook();
+	}
+
+	namespace CL_CheckForPureServerWhitelist {
+		using fn = void(__thiscall*)(void*);
+		inline fn original;
+		void __fastcall hook(void* edx, void* ecx);
+	}
+	#pragma endregion
 }

--- a/src/core/menu/menu.cpp
+++ b/src/core/menu/menu.cpp
@@ -264,6 +264,7 @@ void menu::render() {
 				gui::check_box(item_left_pos, part3c2_base_item_y + (15 * 7), item_checkbox_pos, render::fonts::watermark_font,
 					"Recoil crosshair", variables::misc_visuals::recoil_crosshair, variables::colors::recoil_crosshair_c);
 			}
+
 			break;
 		}
 		case 2: {	// Misc

--- a/src/dependencies/interfaces/i_client_state.hpp
+++ b/src/dependencies/interfaces/i_client_state.hpp
@@ -52,42 +52,58 @@ public:
 	virtual float		get_timeout_seconds() const = 0;
 };
 
+class c_event_info {
+public:
+	short				nClassID;		// 0 implies not in use
+	float				flFireDelay;	// if non-zero, the delay time when the event should be fired ( fixed up on the client )
+	const void* pSendTable;
+	const client_class* pClientClass;	// clienclass pointer
+										// @warning: Type might be wrong
+	void* pData;			            // raw event data
+	std::intptr_t		iPackedBits;
+	int					iFlags;
+	std::byte			u0[0x16];	
+}; // Size: 0x30
+
 class i_client_state {
 public:
-	char		u0[ 156 ];
+	std::byte		u0[0x9C];
 	i_net_channel	*net_channel;
-	uint32_t	challenge_nr;
-	char		u1[ 100 ];
-	uint32_t	signon_state_count;
-	char		u2[ 8 ];
-	float		next_cmd_time;
-	uint32_t	server_count;
-	uint32_t	current_sequence;
-	char		u3[ 84 ];
-	uint32_t	delta_tick;
-	bool		paused;
-	char		u4[ 3 ];
-	uint32_t	view_entity;
-	uint32_t	player_slot;
-	char		level_name[ 260 ];
-	char		level_name_short[ 80 ];
-	char		group_name[ 80 ];
-	char		u5[ 92 ];
-	uint32_t	max_clients;
-	char		u6[ 18824 ];
-	float		last_server_tick_time;
-	bool		in_simulation;
-	char		u7[ 3 ];
-	uint32_t	old_tick_count;
-	float		tick_remainder;
-	float		frame_time;
-	int		last_outgoing_command;
-	int		choked_commands;
-	int		last_command_ack;
-	int		command_ack;
-	int		sound_sequence;
-	char		u8[ 80 ];
-	vec3_t		view_angles;
+	uint32_t		challenge_nr;
+	std::byte		u1[0x64];
+	uint32_t		signon_state_count;
+	std::byte		u2[0x8];
+	float			next_cmd_time;
+	uint32_t		server_count;
+	uint32_t		current_sequence;
+	std::byte		u3[0x54];
+	uint32_t		delta_tick;
+	bool			paused;
+	std::byte		u4[0x7];
+	uint32_t		view_entity;
+	uint32_t		player_slot;
+	char			level_name[260];
+	char			level_name_short[80];
+	char			group_name[80];
+	char			last_level_name_short[80];
+	std::byte		u5[0xC];
+	uint32_t		max_clients;
+	std::byte		u6[0x498C];
+	float			last_server_tick_time;
+	bool			in_simulation;
+	std::byte		u7[0x3];
+	uint32_t		old_tick_count;
+	float			tick_remainder;
+	float			frame_time;
+	int				last_outgoing_command;
+	int				choked_commands;
+	int				last_command_ack;
+	int				command_ack;
+	int				sound_sequence;
+	std::byte		u8[0x50];
+	vec3_t			view_angles;
+	std::byte		u9[0xD0];
+	c_event_info*	pEvents;
 
 	void full_update() {
 		delta_tick = -1;

--- a/src/dependencies/interfaces/i_client_string_table_container.hpp
+++ b/src/dependencies/interfaces/i_client_string_table_container.hpp
@@ -1,6 +1,24 @@
 #pragma once
 
-class i_network_string_table;
+#define INVALID_STRING_TABLE -1
+#define INVALID_STRING_INDEX (std::uint16_t)~0
+
+class i_network_string_table {
+public:
+	virtual					~i_network_string_table() { }
+	virtual const char* GetTableName() const = 0;
+	virtual int				GetTableId() const = 0;
+	virtual int				GetNumStrings() const = 0;
+	virtual int				GetMaxStrings() const = 0;
+	virtual int				GetEntryBits() const = 0;
+	virtual void			SetTick(int iTick) = 0;
+	virtual bool			ChangedSinceTick(int iTick) const = 0;
+	virtual int				AddString(bool bIsServer, const char* szValue, int iLength = -1, const void* pUserData = 0) = 0;
+	virtual const char* GetString(int nString) = 0;
+	virtual void			SetStringUserData(int nString, int iLength, const void* pUserData) = 0;
+	virtual const void* GetStringUserData(int nString, int* iLength) = 0;
+	virtual int				FindStringIndex(char const* szString) = 0;
+};
 
 class i_client_string_table_container {
 public:

--- a/src/dependencies/interfaces/i_client_string_table_container.hpp
+++ b/src/dependencies/interfaces/i_client_string_table_container.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+class i_network_string_table;
+
+class i_client_string_table_container {
+public:
+    i_network_string_table* find_table(const char* tableName) {
+        using original_fn = i_network_string_table* (__thiscall*)(void*, const char*);
+        return (*(original_fn**)this)[3](this, tableName);
+    }
+};

--- a/src/dependencies/interfaces/i_filesystem.hpp
+++ b/src/dependencies/interfaces/i_filesystem.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+class i_filesystem {
+public:
+
+};

--- a/src/dependencies/interfaces/i_game_event_manager.hpp
+++ b/src/dependencies/interfaces/i_game_event_manager.hpp
@@ -23,13 +23,15 @@ public:
 	virtual float           get_float( const char *name = nullptr, float def = 0.0f ) = 0;
 	virtual const char		*get_string( const char *name = nullptr, const char *def = "" ) = 0;
 	virtual const wchar_t	*get_wstring( const char *name, const wchar_t *def = L"" ) = 0;
-
+	virtual const void*		get_ptr(const char* szKeyName = nullptr) const = 0;
+	
 	virtual void            set_bool( const char *name, bool value ) = 0;
 	virtual void            set_int( const char *name, int value ) = 0;
 	virtual void            set_uint_64( const char *name, unsigned long value ) = 0;
 	virtual void            set_float( const char *name, float value ) = 0;
 	virtual void            set_string( const char *name, const char *value ) = 0;
 	virtual void            set_wstring( const char *name, const wchar_t *value ) = 0;
+	virtual void			set_ptr(const char* szKeyName, const void* pValue) = 0;
 };
 
 class i_game_event_listener2 {

--- a/src/dependencies/interfaces/interfaces.cpp
+++ b/src/dependencies/interfaces/interfaces.cpp
@@ -2,26 +2,27 @@
 #include "dependencies/utilities/csgo.hpp"
 
 bool interfaces::initialize() {
-	client                = get_interface<i_base_client_dll, interface_type::index>("client.dll", "VClient018");
-	entity_list           = get_interface<i_client_entity_list, interface_type::index>("client.dll", "VClientEntityList003");
-	engine                = get_interface<iv_engine_client, interface_type::index>("engine.dll", "VEngineClient014");
-	panel                 = get_interface<i_panel, interface_type::index>("vgui2.dll", "VGUI_Panel009");
-	surface               = get_interface<i_surface, interface_type::index>("vguimatsurface.dll", "VGUI_Surface031");
-	material_system       = get_interface<i_material_system, interface_type::index>("materialsystem.dll", "VMaterialSystem080");
-	model_info            = get_interface<iv_model_info, interface_type::index>("engine.dll", "VModelInfoClient004");
-	model_render          = get_interface<iv_model_render, interface_type::index>("engine.dll", "VEngineModel016");
-	studio_render         = get_interface<iv_studio_render, interface_type::index>("studiorender.dll", "VStudioRender026");		// For chams
-	render_view           = get_interface<i_render_view, interface_type::index>("engine.dll", "VEngineRenderView014");
-	console               = get_interface<i_console, interface_type::index>("vstdlib.dll", "VEngineCvar007");
-	localize              = get_interface<i_localize, interface_type::index>("localize.dll", "Localize_001");
-	event_manager         = get_interface<i_game_event_manager2, interface_type::index>("engine.dll", "GAMEEVENTSMANAGER002");
-	debug_overlay         = get_interface<iv_debug_overlay, interface_type::index>("engine.dll", "VDebugOverlay004");
-	input_system          = get_interface<i_input_system, interface_type::index>("inputsystem.dll", "InputSystemVersion001");
-	trace_ray             = get_interface<trace, interface_type::index>("engine.dll", "EngineTraceClient004");
-	game_movement         = get_interface<player_game_movement, interface_type::index>("client.dll", "GameMovement001");
-	prediction            = get_interface<player_prediction, interface_type::index>("client.dll", "VClientPrediction001");
-	mdl_cache             = get_interface<mdlcache, interface_type::index>("datacache.dll", "MDLCache004");
-	surface_props_physics = get_interface<physics_surface_props, interface_type::index>("vphysics.dll", "VPhysicsSurfaceProps001");
+	client                        = get_interface<i_base_client_dll, interface_type::index>("client.dll", "VClient018");
+	entity_list                   = get_interface<i_client_entity_list, interface_type::index>("client.dll", "VClientEntityList003");
+	engine                        = get_interface<iv_engine_client, interface_type::index>("engine.dll", "VEngineClient014");
+	panel                         = get_interface<i_panel, interface_type::index>("vgui2.dll", "VGUI_Panel009");
+	surface                       = get_interface<i_surface, interface_type::index>("vguimatsurface.dll", "VGUI_Surface031");
+	material_system               = get_interface<i_material_system, interface_type::index>("materialsystem.dll", "VMaterialSystem080");
+	model_info                    = get_interface<iv_model_info, interface_type::index>("engine.dll", "VModelInfoClient004");
+	model_render                  = get_interface<iv_model_render, interface_type::index>("engine.dll", "VEngineModel016");
+	studio_render                 = get_interface<iv_studio_render, interface_type::index>("studiorender.dll", "VStudioRender026");		// For chams
+	render_view                   = get_interface<i_render_view, interface_type::index>("engine.dll", "VEngineRenderView014");
+	console                       = get_interface<i_console, interface_type::index>("vstdlib.dll", "VEngineCvar007");
+	localize                      = get_interface<i_localize, interface_type::index>("localize.dll", "Localize_001");
+	event_manager                 = get_interface<i_game_event_manager2, interface_type::index>("engine.dll", "GAMEEVENTSMANAGER002");
+	debug_overlay                 = get_interface<iv_debug_overlay, interface_type::index>("engine.dll", "VDebugOverlay004");
+	input_system                  = get_interface<i_input_system, interface_type::index>("inputsystem.dll", "InputSystemVersion001");
+	trace_ray                     = get_interface<trace, interface_type::index>("engine.dll", "EngineTraceClient004");
+	game_movement                 = get_interface<player_game_movement, interface_type::index>("client.dll", "GameMovement001");
+	prediction                    = get_interface<player_prediction, interface_type::index>("client.dll", "VClientPrediction001");
+	mdl_cache                     = get_interface<mdlcache, interface_type::index>("datacache.dll", "MDLCache004");
+	surface_props_physics         = get_interface<physics_surface_props, interface_type::index>("vphysics.dll", "VPhysicsSurfaceProps001");
+	client_string_table_container = get_interface<i_client_string_table_container, interface_type::index>("engine.dll", "VEngineClientStringTable001");
 
 	/* ------------------ Custom interfaces ------------------ */
 

--- a/src/dependencies/interfaces/interfaces.cpp
+++ b/src/dependencies/interfaces/interfaces.cpp
@@ -2,6 +2,7 @@
 #include "dependencies/utilities/csgo.hpp"
 
 bool interfaces::initialize() {
+	// https://gitlab.com/KittenPopo/csgo-2018-source/-/blob/main/public/interfaces/interfaces.h
 	client                        = get_interface<i_base_client_dll, interface_type::index>("client.dll", "VClient018");
 	entity_list                   = get_interface<i_client_entity_list, interface_type::index>("client.dll", "VClientEntityList003");
 	engine                        = get_interface<iv_engine_client, interface_type::index>("engine.dll", "VEngineClient014");
@@ -23,6 +24,7 @@ bool interfaces::initialize() {
 	mdl_cache                     = get_interface<mdlcache, interface_type::index>("datacache.dll", "MDLCache004");
 	surface_props_physics         = get_interface<physics_surface_props, interface_type::index>("vphysics.dll", "VPhysicsSurfaceProps001");
 	client_string_table_container = get_interface<i_client_string_table_container, interface_type::index>("engine.dll", "VEngineClientStringTable001");
+	filesystem                    = get_interface<i_filesystem, interface_type::index>("filesystem_stdio.dll", "VFileSystem017");
 
 	/* ------------------ Custom interfaces ------------------ */
 

--- a/src/dependencies/interfaces/interfaces.hpp
+++ b/src/dependencies/interfaces/interfaces.hpp
@@ -30,6 +30,7 @@
 #include "dependencies/interfaces/i_mdlcache.hpp"
 #include "dependencies/interfaces/i_physics_surface_props.hpp"
 #include "dependencies/interfaces/i_client_string_table_container.hpp"
+#include "dependencies/interfaces/i_filesystem.hpp"
 
 namespace interfaces {
 	enum class interface_type { index, bruteforce };
@@ -101,6 +102,7 @@ namespace interfaces {
 	inline i_weapon_system* weapon_system;
 	inline physics_surface_props* surface_props_physics;
 	inline i_client_string_table_container* client_string_table_container;
+	inline i_filesystem* filesystem;
 
 	// https://github.com/cazzwastaken/based/search?q=keyValuesSystem
 	inline void* key_values_system = nullptr;

--- a/src/dependencies/interfaces/interfaces.hpp
+++ b/src/dependencies/interfaces/interfaces.hpp
@@ -29,6 +29,7 @@
 #include "dependencies/interfaces/i_studio_render.h"
 #include "dependencies/interfaces/i_mdlcache.hpp"
 #include "dependencies/interfaces/i_physics_surface_props.hpp"
+#include "dependencies/interfaces/i_client_string_table_container.hpp"
 
 namespace interfaces {
 	enum class interface_type { index, bruteforce };
@@ -99,6 +100,7 @@ namespace interfaces {
 	inline mdlcache* mdl_cache;
 	inline i_weapon_system* weapon_system;
 	inline physics_surface_props* surface_props_physics;
+	inline i_client_string_table_container* client_string_table_container;
 
 	// https://github.com/cazzwastaken/based/search?q=keyValuesSystem
 	inline void* key_values_system = nullptr;

--- a/src/dependencies/interfaces/iv_model_info.hpp
+++ b/src/dependencies/interfaces/iv_model_info.hpp
@@ -5,19 +5,23 @@
 class iv_model_info {
 public:
 	model_t* get_model(int index) {
-		using original_fn = model_t * (__thiscall*)(iv_model_info*, int);
-		return (*(original_fn * *)this)[1](this, index);
+		using original_fn = model_t* (__thiscall*)(iv_model_info*, int);
+		return (*(original_fn**)this)[1](this, index);
 	}
 	int get_model_index(const char* filename) {
 		using original_fn = int(__thiscall*)(iv_model_info*, const char*);
-		return (*(original_fn * *)this)[2](this, filename);
+		return (*(original_fn**)this)[2](this, filename);
 	}
 	const char* get_model_name(const model_t* model) {
 		using original_fn = const char* (__thiscall*)(iv_model_info*, const model_t*);
-		return (*(original_fn * *)this)[3](this, model);
+		return (*(original_fn**)this)[3](this, model);
 	}
 	studio_hdr_t* get_studio_model(const model_t* model) {
-		using original_fn = studio_hdr_t * (__thiscall*)(iv_model_info*, const model_t*);
-		return (*(original_fn * *)this)[32](this, model);
+		using original_fn = studio_hdr_t* (__thiscall*)(iv_model_info*, const model_t*);
+		return (*(original_fn**)this)[32](this, model);
+	}
+	model_t* find_or_load_model(const char* filename) {
+		using original_fn = model_t* (__thiscall*)(iv_model_info*, const char* filename);
+		return (*(original_fn**)this)[43](this, filename);
 	}
 };

--- a/src/dependencies/utilities/csgo.hpp
+++ b/src/dependencies/utilities/csgo.hpp
@@ -42,18 +42,18 @@
 #define sig_trace_to_exit          "55 8B EC 83 EC 4C F3 0F 10 75"					// For autowall
 
 // custom for the hooks
-#define sig_key_values_engine           "85 C0 74 ? 51 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
-#define sig_key_values_client           "85 C0 74 ? 6A ? 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
-#define sig_client_model_renderable     "56 8B F1 80 BE ? ? ? ? ? 0F 84 ? ? ? ? 80 BE"
-#define sig_depth_of_field              "8B 0D ? ? ? ? 56 8B 01 FF 50 ? 8B F0 85 F6 75 ?"
-#define sig_draw_screen_effect_material "55 8B EC 83 E4 ? 83 EC ? 53 56 57 8D 44 24 ? 89 4C 24 ?"
-#define sig_supports_resolve_depth      "A1 ? ? ? ? A8 ? 75 ? 83 C8 ? B9 ? ? ? ? 68 ? ? ? ? A3"
-#define sig_fire_event                  "55 8B EC 83 E4 F8 83 EC 0C 53 8B D9 56 57 89 5C 24 0C"
-#define sig_view_render                 "8B 0D ? ? ? ? FF 75 0C 8B 45 08"
-#define sig_viewmodel_sequence          "55 8B EC 53 8B 5D 08 57 8B 7D 0C 8B"
-#define sig_filesystem                  "8B 0D ? ? ? ? 8D 95 ? ? ? ? 6A 00 C6"
-#define sig_CheckForPureServerWhitelist "8B 0D ? ? ? ? 56 83 B9 ? ? ? ? ? 7E 6E"
-#define sig_update_visibility			"55 8B EC 83 E4 F8 83 EC 24 53 56 57 8B F9 8D"
+#define sig_key_values_engine              "85 C0 74 ? 51 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
+#define sig_key_values_client              "85 C0 74 ? 6A ? 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
+#define sig_client_model_renderable        "56 8B F1 80 BE ? ? ? ? ? 0F 84 ? ? ? ? 80 BE"
+#define sig_depth_of_field                 "8B 0D ? ? ? ? 56 8B 01 FF 50 ? 8B F0 85 F6 75 ?"
+#define sig_draw_screen_effect_material    "55 8B EC 83 E4 ? 83 EC ? 53 56 57 8D 44 24 ? 89 4C 24 ?"
+#define sig_supports_resolve_depth         "A1 ? ? ? ? A8 ? 75 ? 83 C8 ? B9 ? ? ? ? 68 ? ? ? ? A3"
+#define sig_fire_event                     "55 8B EC 83 E4 F8 83 EC 0C 53 8B D9 56 57 89 5C 24 0C"
+#define sig_view_render                    "8B 0D ? ? ? ? FF 75 0C 8B 45 08"
+#define sig_viewmodel_sequence             "55 8B EC 53 8B 5D 08 57 8B 7D 0C 8B"
+#define sig_filesystem                     "8B 0D ? ? ? ? 8D 95 ? ? ? ? 6A 00 C6"
+#define sig_CheckForPureServerWhitelist    "8B 0D ? ? ? ? 56 83 B9 ? ? ? ? ? 7E 6E"
+#define sig_update_visibility			   "55 8B EC 83 E4 F8 83 EC 24 53 56 57 8B F9 8D"
 
 namespace csgo {
 	extern player_t* local_player;

--- a/src/dependencies/utilities/csgo.hpp
+++ b/src/dependencies/utilities/csgo.hpp
@@ -27,33 +27,34 @@
 #include "core/helpers/globas.hpp"
 
 //interfaces
-#define sig_client_state       "A1 ? ? ? ? 8B 80 ? ? ? ? C3"
-#define sig_directx            "A1 ? ? ? ? 50 8B 08 FF 51 0C"
-#define sig_input              "B9 ? ? ? ? F3 0F 11 04 24 FF 50 10"
-#define sig_glow_manager       "0F 11 05 ? ? ? ? 83 C8 01 C7 05 ? ? ? ? 00 00 00 00"
-#define sig_player_move_helper "8B 0D ? ? ? ? 8B 46 08 68"
-#define sig_weapon_data        "8B 35 ? ? ? ? FF 10 0F B7 C0"
+#define sig_client_state		"A1 ? ? ? ? 8B 80 ? ? ? ? C3"
+#define sig_directx				"A1 ? ? ? ? 50 8B 08 FF 51 0C"
+#define sig_input				"B9 ? ? ? ? F3 0F 11 04 24 FF 50 10"
+#define sig_glow_manager		"0F 11 05 ? ? ? ? 83 C8 01 C7 05 ? ? ? ? 00 00 00 00"
+#define sig_player_move_helper	"8B 0D ? ? ? ? 8B 46 08 68"
+#define sig_weapon_data			"8B 35 ? ? ? ? FF 10 0F B7 C0"
 
 //misc
-#define sig_set_angles             "55 8B EC 83 E4 F8 83 EC 64 53 56 57 8B F1 E8"
-#define sig_prediction_player	   "89 35 ? ? ? ? F3 0F 10 48"
-#define sig_prediction_random_seed "A3 ? ? ? ? 66 ? ? 86"
-#define sig_viewmatrix             "0F 10 05 ? ? ? ? 8D 85 ? ? ? ? B9"
-#define sig_trace_to_exit          "55 8B EC 83 EC 4C F3 0F 10 75"					// For autowall
+#define sig_set_angles				"55 8B EC 83 E4 F8 83 EC 64 53 56 57 8B F1 E8"
+#define sig_prediction_player		"89 35 ? ? ? ? F3 0F 10 48"
+#define sig_prediction_random_seed	"A3 ? ? ? ? 66 ? ? 86"
+#define sig_viewmatrix				"0F 10 05 ? ? ? ? 8D 85 ? ? ? ? B9"
+#define sig_trace_to_exit			"55 8B EC 83 EC 4C F3 0F 10 75"					// For autowall
 
 // custom for the hooks
-#define sig_key_values_engine              "85 C0 74 ? 51 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
-#define sig_key_values_client              "85 C0 74 ? 6A ? 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
-#define sig_client_model_renderable        "56 8B F1 80 BE ? ? ? ? ? 0F 84 ? ? ? ? 80 BE"
-#define sig_depth_of_field                 "8B 0D ? ? ? ? 56 8B 01 FF 50 ? 8B F0 85 F6 75 ?"
-#define sig_draw_screen_effect_material    "55 8B EC 83 E4 ? 83 EC ? 53 56 57 8D 44 24 ? 89 4C 24 ?"
-#define sig_supports_resolve_depth         "A1 ? ? ? ? A8 ? 75 ? 83 C8 ? B9 ? ? ? ? 68 ? ? ? ? A3"
-#define sig_fire_event                     "55 8B EC 83 E4 F8 83 EC 0C 53 8B D9 56 57 89 5C 24 0C"
-#define sig_view_render                    "8B 0D ? ? ? ? FF 75 0C 8B 45 08"
-#define sig_viewmodel_sequence             "55 8B EC 53 8B 5D 08 57 8B 7D 0C 8B"
-#define sig_filesystem                     "8B 0D ? ? ? ? 8D 95 ? ? ? ? 6A 00 C6"
-#define sig_CheckForPureServerWhitelist    "8B 0D ? ? ? ? 56 83 B9 ? ? ? ? ? 7E 6E"
-#define sig_update_visibility			   "55 8B EC 83 E4 F8 83 EC 24 53 56 57 8B F9 8D"
+#define sig_key_values_engine					"85 C0 74 ? 51 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
+#define sig_key_values_client					"85 C0 74 ? 6A ? 6A ? 56 8B C8 E8 ? ? ? ? 8B F0"
+#define sig_client_model_renderable				"56 8B F1 80 BE ? ? ? ? ? 0F 84 ? ? ? ? 80 BE"
+#define sig_depth_of_field						"8B 0D ? ? ? ? 56 8B 01 FF 50 ? 8B F0 85 F6 75 ?"
+#define sig_draw_screen_effect_material			"55 8B EC 83 E4 ? 83 EC ? 53 56 57 8D 44 24 ? 89 4C 24 ?"
+#define sig_supports_resolve_depth				"A1 ? ? ? ? A8 ? 75 ? 83 C8 ? B9 ? ? ? ? 68 ? ? ? ? A3"
+#define sig_fire_event							"55 8B EC 83 E4 F8 83 EC 0C 53 8B D9 56 57 89 5C 24 0C"
+#define sig_view_render							"8B 0D ? ? ? ? FF 75 0C 8B 45 08"
+#define sig_viewmodel_sequence					"55 8B EC 53 8B 5D 08 57 8B 7D 0C 8B"
+#define sig_filesystem							"8B 0D ? ? ? ? 8D 95 ? ? ? ? 6A 00 C6"
+#define sig_CheckForPureServerWhitelist			"8B 0D ? ? ? ? 56 83 B9 ? ? ? ? ? 7E 6E"
+#define sig_update_visibility					"55 8B EC 83 E4 F8 83 EC 24 53 56 57 8B F9 8D"
+#define sig_update_visibility_all_enttities		"53 56 66 8B 35 ? ? ? ? BB ? ? ? ? 57 90 66 3B F3 74 ? A1"
 
 namespace csgo {
 	extern player_t* local_player;

--- a/src/dependencies/utilities/csgo.hpp
+++ b/src/dependencies/utilities/csgo.hpp
@@ -51,6 +51,8 @@
 #define sig_fire_event                  "55 8B EC 83 E4 F8 83 EC 0C 53 8B D9 56 57 89 5C 24 0C"
 #define sig_view_render                 "8B 0D ? ? ? ? FF 75 0C 8B 45 08"
 #define sig_viewmodel_sequence          "55 8B EC 53 8B 5D 08 57 8B 7D 0C 8B"
+#define sig_filesystem                  "8B 0D ? ? ? ? 8D 95 ? ? ? ? 6A 00 C6"
+#define sig_CheckForPureServerWhitelist "8B 0D ? ? ? ? 56 83 B9 ? ? ? ? ? 7E 6E"
 
 namespace csgo {
 	extern player_t* local_player;

--- a/src/source-sdk/classes/entities.hpp
+++ b/src/source-sdk/classes/entities.hpp
@@ -305,7 +305,7 @@ const std::unordered_map<std::string, int> all_item_definition_indexes = {
 };
 
 const std::unordered_map<std::string, int> all_custom_models = {
-	{ "LOCAL_PLAYER",					LOCAL_PLAYER  },
+	{ "LOCAL_PLAYER",					LOCAL_PLAYER },
 	{ "PLAYER_ALLY",					PLAYER_ALLY },
 	{ "PLAYER_ENEMY",					PLAYER_ENEMY },
 	//{ "ARMS",							ARMS }

--- a/src/source-sdk/classes/entities.hpp
+++ b/src/source-sdk/classes/entities.hpp
@@ -308,7 +308,7 @@ const std::unordered_map<std::string, int> all_custom_models = {
 	{ "LOCAL_PLAYER",					LOCAL_PLAYER },
 	{ "PLAYER_ALLY",					PLAYER_ALLY },
 	{ "PLAYER_ENEMY",					PLAYER_ENEMY },
-	//{ "ARMS",							ARMS }
+	{ "ARMS",							ARMS }
 };
 
 struct collideable_t {
@@ -462,15 +462,15 @@ public:
 	NETVAR("DT_WeaponCSBaseGun",  "m_zoomLevel",                zoom_level,                  float)
 
 	#pragma region BaseAttributableItem
-	NETVAR("DT_BaseAttributableItem", "m_iItemDefinitionIndex", item_definition_index, short)
-	NETVAR("DT_BaseAttributableItem", "m_iItemIDHigh",          item_id_high,		   int)
-	NETVAR("DT_BaseAttributableItem", "m_iAccountID",           account_id,			   int)
-	NETVAR("DT_BaseAttributableItem", "m_iEntityQuality",       entity_quality,		   int)
-	NETVAR("DT_BaseAttributableItem", "m_szCustomName",         custom_name,		   const char*)
-	NETVAR("DT_BaseAttributableItem", "m_nFallbackPaintKit",    fallback_paint_kit,	   int)
-	NETVAR("DT_BaseAttributableItem", "m_nFallbackSeed",        fallback_seed,		   int)
-	NETVAR("DT_BaseAttributableItem", "m_flFallbackWear",       fallback_wear,		   float)
-	NETVAR("DT_BaseAttributableItem", "m_nFallbackStatTrak",    fallback_stattrack,	   int)
+	NETVAR("DT_BaseAttributableItem",		"m_iItemDefinitionIndex",	item_definition_index, short)
+	NETVAR("DT_BaseAttributableItem",		"m_iItemIDHigh",			item_id_high,		   int)
+	NETVAR("DT_BaseAttributableItem",		"m_iAccountID",				account_id,			   int)
+	NETVAR("DT_BaseAttributableItem",		"m_iEntityQuality",			entity_quality,		   int)
+	NETVAR_PTR("DT_BaseAttributableItem",	"m_szCustomName",			custom_name,		   char)
+	NETVAR("DT_BaseAttributableItem",		"m_nFallbackPaintKit",		fallback_paint_kit,	   int)
+	NETVAR("DT_BaseAttributableItem",		"m_nFallbackSeed",			fallback_seed,		   int)
+	NETVAR("DT_BaseAttributableItem",		"m_flFallbackWear",			fallback_wear,		   float)
+	NETVAR("DT_BaseAttributableItem",		"m_nFallbackStatTrak",		fallback_stattrack,	   int)
 	#pragma endregion
 
 	float inaccuracy() {
@@ -580,7 +580,7 @@ public:
 	NETVAR("DT_CSPlayer", "m_iHealth", health, int)
 	NETVAR("DT_CSPlayer", "m_lifeState", life_state, int)
 	NETVAR("DT_CSPlayer", "m_fFlags", flags, int)
-	NETVAR("DT_CSPlayer", "m_szArmsModel", arms_model, const char*)
+	NETVAR_PTR("DT_CSPlayer", "m_szArmsModel", arms_model, char)
 	NETVAR("DT_BasePlayer", "m_viewPunchAngle", punch_angle, vec3_t)
 	NETVAR("DT_BasePlayer", "m_aimPunchAngle", aim_punch_angle, vec3_t)
 	NETVAR("DT_BasePlayer", "m_vecVelocity[0]", velocity, vec3_t)

--- a/src/source-sdk/classes/entities.hpp
+++ b/src/source-sdk/classes/entities.hpp
@@ -732,7 +732,7 @@ public:
 
 	void update_client_side_animations() {
 		using original_fn = void(__thiscall*)(void*);
-		(*(original_fn * *)this)[224](this);
+		(*(original_fn**)this)[224](this);
 	}
 
 	vec3_t& abs_origin() {

--- a/src/source-sdk/classes/entities.hpp
+++ b/src/source-sdk/classes/entities.hpp
@@ -201,6 +201,14 @@ enum item_definition_indexes {
 	GLOVE_HYDRA = 5035
 };
 
+// Misc models
+enum {
+	LOCAL_PLAYER = 10000,
+	PLAYER_ALLY,
+	PLAYER_ENEMY,
+	ARMS
+};
+
 // Array with all the items and names used for iteration and configs.
 // Used in read_skins.cpp
 const std::unordered_map<std::string, int> all_item_definition_indexes = {
@@ -294,6 +302,13 @@ const std::unordered_map<std::string, int> all_item_definition_indexes = {
 	{ "GLOVE_MOTORCYCLE",				GLOVE_MOTORCYCLE },
 	{ "GLOVE_SPECIALIST",				GLOVE_SPECIALIST },
 	{ "GLOVE_HYDRA",					GLOVE_HYDRA }
+};
+
+const std::unordered_map<std::string, int> all_custom_models = {
+	{ "LOCAL_PLAYER",					LOCAL_PLAYER  },
+	{ "PLAYER_ALLY",					PLAYER_ALLY },
+	{ "PLAYER_ENEMY",					PLAYER_ENEMY },
+	//{ "ARMS",							ARMS }
 };
 
 struct collideable_t {
@@ -451,7 +466,7 @@ public:
 	NETVAR("DT_BaseAttributableItem", "m_iItemIDHigh",          item_id_high,		   int)
 	NETVAR("DT_BaseAttributableItem", "m_iAccountID",           account_id,			   int)
 	NETVAR("DT_BaseAttributableItem", "m_iEntityQuality",       entity_quality,		   int)
-	//NETVAR("DT_BaseAttributableItem", "m_szCustomName",         custom_name,		   char)		// Commented cuz crashes
+	NETVAR("DT_BaseAttributableItem", "m_szCustomName",         custom_name,		   const char*)
 	NETVAR("DT_BaseAttributableItem", "m_nFallbackPaintKit",    fallback_paint_kit,	   int)
 	NETVAR("DT_BaseAttributableItem", "m_nFallbackSeed",        fallback_seed,		   int)
 	NETVAR("DT_BaseAttributableItem", "m_flFallbackWear",       fallback_wear,		   float)
@@ -565,6 +580,7 @@ public:
 	NETVAR("DT_CSPlayer", "m_iHealth", health, int)
 	NETVAR("DT_CSPlayer", "m_lifeState", life_state, int)
 	NETVAR("DT_CSPlayer", "m_fFlags", flags, int)
+	NETVAR("DT_CSPlayer", "m_szArmsModel", arms_model, const char*)
 	NETVAR("DT_BasePlayer", "m_viewPunchAngle", punch_angle, vec3_t)
 	NETVAR("DT_BasePlayer", "m_aimPunchAngle", aim_punch_angle, vec3_t)
 	NETVAR("DT_BasePlayer", "m_vecVelocity[0]", velocity, vec3_t)


### PR DESCRIPTION
### Changes:
- Add precached models
    - [X] Weapons
    - [X] Players
    - [x] Localplayer
    - [x] Arms (Replacing `"m_szArmsModel"`)
- Add model options to `skins.json`
- Add knife icon replacement for weapons with custom `item_definition_index` (Changed knifes)
- Add sv_pure bypass (Only experienced [this](https://user-images.githubusercontent.com/29655971/180574180-b67051de-a5ab-4bc3-906e-83fbd5f3cc47.png) when using a custom localplayer model on a flying scout match)
- Fix model flickering
- Thirdperson improvements

### Bugs:
- [X] Forcing update during thirdperson crashes. This happenend before the pull request. See ~~[this](https://github.com/r4v10l1/NullHooks/blob/8569a5a593a3407f6920189ec363cd669ae4fdbc/src/core/hooks/functions/frame_stage_notify.cpp#L38), [this](https://github.com/r4v10l1/NullHooks/blob/8569a5a593a3407f6920189ec363cd669ae4fdbc/src/core/hooks/functions/frame_stage_notify.cpp#L32) and~~ [this](https://github.com/r4v10l1/NullHooks/blob/8569a5a593a3407f6920189ec363cd669ae4fdbc/src/core/features/misc/thirdperson.cpp#L75-L76) for possible fixes/errors I noticed while debugging.  
    *Update: If you remove [update_visibility](https://github.com/r4v10l1/NullHooks/blob/8569a5a593a3407f6920189ec363cd669ae4fdbc/src/core/features/misc/thirdperson.cpp#L73-L76) it does not crash, even with custom models, without [disabling thirdperson](https://github.com/r4v10l1/NullHooks/blob/8569a5a593a3407f6920189ec363cd669ae4fdbc/src/core/hooks/functions/frame_stage_notify.cpp#L22-L23) and with animation fix.*  
    *Update: Fixed by replacing `update_visibility()` with `update_visibility_all_entities()`*